### PR TITLE
Comment and name fixes to unit test

### DIFF
--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/WorkbookViewAttrsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/WorkbookViewAttrsTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
-class HiddenTabsTest extends TestCase
+class WorkbookViewAttrsTest extends TestCase
 {
     /**
      * Copy of PhpOffice\PhpSpreadsheet\Writer\Xlsx\Workbook::$bookViewAttributes
@@ -27,10 +27,13 @@ class HiddenTabsTest extends TestCase
     ];
 
     /**
-     * Test that the worksheet tabs remain hidden when reading and writing a XLSX document
-     * with hidden worksheets tabs.
+     * Test that workbook bookview attributes such as 'showSheetTabs',
+     * (the attribute controlling worksheet tabs visibility,)
+     * are preserved when xlsx documents are read and written.
+     *
+     * @see https://github.com/PHPOffice/PhpSpreadsheet/issues/523
      */
-    public function testUpdateWithHiddenTabs()
+    public function testPreserveWorkbookViewAttributes()
     {
         // Create a dummy workbook with two worksheets
         $workbook = new Spreadsheet();


### PR DESCRIPTION
* Renamed the test script to reflect that it tests all workbook
  bookview attributes, not just the 'showSheetTabs' attribute.
* Rewrote the comment for the test case to indicate that it
  tests all workbook bookvview attributes.

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
